### PR TITLE
更新機能追加

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -33,4 +33,17 @@ class BookController extends Controller
         $book->save();
         return redirect()->route('books.index');
     }
+
+    // 本情報更新画面表示アクション
+    public function edit(Book $book)
+    {
+        return view('books.edit', ['book' => $book]);    
+    }
+
+    // 本情報更新処理アクション
+    public function update(BookRequest $request, Book $book)
+    {
+        $book->fill($request->all())->save();
+        return redirect()->route('books.index');
+    }
 }

--- a/resources/views/books/form.blade.php
+++ b/resources/views/books/form.blade.php
@@ -1,25 +1,25 @@
 @csrf
 <div class="md-form">
   <label>タイトル</label>
-  <input type="text" name="title" class="form-control" required value="{{ old('title') }}">
+  <input type="text" name="title" class="form-control" required value="{{ $book->title ?? old('title') }}">
 </div>
 <div class="md-form">
   <label>著者名</label>
-  <input type="text" name="author" class="form-control" value="{{ old('author') }}">
+  <input type="text" name="author" class="form-control" value="{{ $book->author ?? old('author') }}">
 </div>
 <div class="md-form">
   <label>出版社</label>
-  <input type="text" name="publisher" class="form-control" value="{{ old('publisher') }}">
+  <input type="text" name="publisher" class="form-control" value="{{ $book->publisher ?? old('publisher') }}">
 </div>
 <div class="md-form">
   <label>表紙画像</label>
-  <input type="text" name="book_image" class="form-control" value="{{ old('book_image') }}">
+  <input type="text" name="book_image" class="form-control" value="{{ $book->book_image ?? old('book_image') }}">
 </div>
 <div class="md-form">
-  <input type="radio" name="state" class="form-control" value="1" checked="checked">貸出できます
+  <input type="radio" name="state" class="form-control" value="1">貸出できます
   <input type="radio" name="state" class="form-control" value="2">貸出できません
 </div>
 <div class="form-group">
   <label>本の情報</label>
-  <textarea name="description" required class="form-control" rows="16" placeholder="この書籍の説明">{{ old('description') }}</textarea>
+  <textarea name="description" class="form-control" rows="16" placeholder="この書籍の説明">{{ $book->description ?? old('description') }}</textarea>
 </div>

--- a/resources/views/books/index.blade.php
+++ b/resources/views/books/index.blade.php
@@ -7,23 +7,71 @@
   <div class="container">
     @foreach($books as $book)
       <div class="card mt-3">
-        <div class="card-body flex-row">
-          <p>【タイトル】</p>
-          <div>{{ $book->title }}</div>
-          <p>【著者名】</p>
-          <div>{{ $book->author }}</div>
-          <p>【出版社名】</p>
-          <p>{{ $book->publisher }}</p>
-          <p>【本の情報】</p>
-          <p>{{ $book->description }}</p>
-          <p>【本の表紙画像】</p>
-          <p>{{ $book->book_image }}</p>
-          <p>【本の状態】</p>
-          @if( $book->state === "1" )
-            <p>貸出可能</p>
-          @else
-            <p>貸出不可能</p>
-          @endif
+        <div class="card-body d-flex flex-row">
+        <h3 class="h4 card-title">
+          {{ $book->title }}
+        </h3>
+
+          <!-- 管理者にのみ表示させるアイコンなので、ユーザー判定が今後必要 -->
+          <!-- ここからdropdown -->
+          <div class="ml-auto card-text">
+            <div class="dropdown">
+              <a data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <button type="button" class="btn btn-link text-muted m-0 p-2">
+                  <i class="fas fa-ellipsis-v"></i>
+                </button>
+              </a>
+              <div class="dropdown-menu dropdown-menu-right">
+                <a class="dropdown-item" href="{{ route("books.edit", ['book' => $book]) }}">
+                  <i class="fas fa-pen mr-1"></i>記事を更新する
+                </a>
+                <div class="dropdown-divider"></div>
+                <a class="dropdown-item text-danger" data-toggle="modal" data-target="#modal-delete-{{ $book->id }}">
+                  <i class="fas fa-trash-alt mr-1"></i>記事を削除する
+                </a>
+              </div>
+            </div>
+          </div>
+          <!-- ここまでdropdown -->
+  
+          <!-- ここからmodal -->
+          <div id="modal-delete-{{ $book->id }}" class="modal fade" tabindex="-1" role="dialog">
+            <div class="modal-dialog" role="document">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <button type="button" class="close" data-dismiss="modal" aria-label="閉じる">
+                    <span aria-hidden="true">×</span>
+                  </button>
+                </div>
+                <form method="POST" action="{{ route('books.destroy', ['book' => $book]) }}">
+                  @csrf
+                  @method('DELETE')
+                  <div class="modal-body">
+                    {{ $book->title }}を削除します。よろしいですか？
+                  </div>
+                  <div class="modal-footer justify-content-between">
+                    <a class="btn btn-outline-grey" data-dismiss="modal">キャンセル</a>
+                    <button type="submit" class="btn btn-danger">削除する</button>
+                  </div>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- ここまでmodal -->
+
+        <div class="card-body pt-0">
+          <div class="card-text">
+            <div>{{ $book->author }}</div>
+            <div>{{ $book->publisher }}</div>
+            <div>{{ $book->description }}</div>
+            <div>{{ $book->book_image }}</div>
+            @if( $book->state === "1" )
+              <div>貸出可能</div>
+            @else
+              <div>貸出不可能</div>
+            @endif
+          </div>
         </div>
       </div>
     @endforeach


### PR DESCRIPTION
目的
・更新機能追加
実装
【form】
・既存データをedit画面に持たせるためにnull合体演算子を使用
【index】
・アイコン押下後dropdownで削除か更新か選択する
・削除の場合はモーダルで確認画面表示
・各項目タイトルを削除
課題
・checkboxのデータを引き継ぐ方法がわからない
・今後は管理者だけが更新・削除処理を実行できるようにユーザー区別の記述が必要