### PR TITLE
メイン画面スタイル変更

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -28,10 +28,17 @@ class BookController extends Controller
         $book->author = $request->author;
         $book->publisher = $request->publisher;
         $book->description = $request->description;
-        $book->book_image = $request->book_image;
         $book->state = $request->state;
+        // 送られてきたファイルに名前をつける
+        // $file_name = $request->file('book_image')->getClientOriginalName();
+        // storage/app/publicにファイルを保存
+        $path = $request->hasFile('book_image')->store('public/images');
+        // 画像名のみ保存
+        $book->book_image = basename($path);
         $book->save();
-        return redirect()->route('books.index');
+        return redirect()
+                ->route('books.index')
+                ->with('file_name', basename($path));
     }
 
     // 本情報更新画面表示アクション

--- a/app/Http/Controllers/CsvimportsController.php
+++ b/app/Http/Controllers/CsvimportsController.php
@@ -74,8 +74,6 @@ class CsvimportsController extends Controller
             }
             $row_count++;
         }
-
-        var_dump($row);
         
         return view('books.index');
     }

--- a/app/Http/Requests/BookRequest.php
+++ b/app/Http/Requests/BookRequest.php
@@ -25,7 +25,7 @@ class BookRequest extends FormRequest
     {
         return [
             'title' => 'required|max:50',
-            'description' => 'required|max:500',
+            'description' => 'max:500',
         ];
     }
 
@@ -34,6 +34,7 @@ class BookRequest extends FormRequest
         return [
             'title' => 'タイトル',
             'description' => '書籍の説明',
+            'book_image' => '表示画像'
         ];
     }
 }

--- a/database/migrations/2020_04_10_001132_create_books_table.php
+++ b/database/migrations/2020_04_10_001132_create_books_table.php
@@ -16,11 +16,11 @@ class CreateBooksTable extends Migration
         Schema::create('books', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('title');
-            $table->string('author');
-            $table->string('book_image');
-            $table->string('publisher');
-            $table->text('description');
-            $table->string('state');
+            $table->string('author')->nullable();
+            $table->string('book_image')->nullable();
+            $table->string('publisher')->nullable();
+            $table->text('description')->nullable();
+            $table->string('state')->nullable();
             $table->timestamps();
         });
     }

--- a/resources/views/books/card.blade.php
+++ b/resources/views/books/card.blade.php
@@ -1,10 +1,25 @@
-<div class="card mt-3">
-  <div class="card-body d-flex flex-row">
-  <h3 class="h4 card-title">
-    <a class="text-dark" href="{{ route('books.show', ['book' => $book]) }}">
-      {{ $book->title }}
-    </a>
-  </h3>
+<!-- ここからCardColumn -->
+<div class="col-lg-4 col-md-12 mb-lg-0 mb-4">
+  
+  <!-- ここからCard -->
+  <div class="card card-cascade wider card-ecommerce mb-4">
+
+    <!-- ここからCardImage -->
+    <div class="view view-cascade overlay">
+      
+      <!-- /public/storage配下に保存している画像を表示 -->
+      @if(!empty($book->book_image))
+      <div class="image-wrapper">
+        <img src="{{ asset('storage/images' . $book->book_image ) }}" alt="image" class="card-img-top">        
+      </div>
+      @else
+      <div class='image-wrapper'>
+        <img src="http://placehold.it/289.98x200" alt="ダミー画像">
+      </div>
+      @endif
+
+    </div>
+    <!-- ここまでCardImage -->
 
     <!-- 管理者にのみ表示させるアイコンなので、ユーザー判定が今後必要 -->
     <!-- ここからdropdown -->
@@ -52,20 +67,37 @@
         </div>
       </div>
     </div>
-  </div>
-  <!-- ここまでmodal -->
+    <!-- ここまでmodal -->
 
-  <div class="card-body pt-0">
-    <div class="card-text">
-      <div>{{ $book->author }}</div>
-      <div>{{ $book->publisher }}</div>
-      <div>{{ $book->description }}</div>
-      <div>{{ $book->book_image }}</div>
-      @if( $book->state === "1" )
-        <div>貸出可能</div>
-      @else
-        <div>貸出不可能</div>
-      @endif
+    <!-- ここからCardContent -->
+    <div class="card-body card-body-cascade text-center">
+      <p class="card-title">
+        <a class="text-dark" href="{{ route('books.show', ['book' => $book]) }}">
+          {{ $book->title }}
+        </a>
+      </p>
+
+      <!-- ここからCardText -->
+      <div class="card-text">
+        <div>{{ $book->author }}</div>
+        <!-- @if( $book->state === "1" )
+          <div>貸出可能</div>
+        @else
+          <div>貸出不可能</div>
+        @endif -->
+
+        <hr>
+        <span class="float-left mt-3">
+          <i class="fas fa-heart ml-1">10</i>
+        </span>
+        <span class="float-right mt-3">
+          <p>予約する</p>
+        </span>
+      </div>
+      <!-- ここまでCardText -->
     </div>
+    <!-- ここまでCardContent -->
   </div>
+  <!-- ここまでCard -->
 </div>
+<!-- ここまでCardColumn -->

--- a/resources/views/books/create.blade.php
+++ b/resources/views/books/create.blade.php
@@ -12,7 +12,7 @@
           <div class="card-body pt-0">
             @include('error_card_list')
             <div class="card-text">
-              <form method="POST" action="{{ route('books.store') }}">
+              <form method="POST" action="{{ route('books.store') }}" enctype="multipart/form-data" >
                 @include('books.form')
                 <button type="submit" class="btn blue-gradient btn-block">登録する</button>
               </form>

--- a/resources/views/books/form.blade.php
+++ b/resources/views/books/form.blade.php
@@ -11,9 +11,9 @@
   <label>出版社</label>
   <input type="text" name="publisher" class="form-control" value="{{ $book->publisher ?? old('publisher') }}">
 </div>
+<p>表示画像</p>
 <div class="md-form">
-  <label>表紙画像</label>
-  <input type="text" name="book_image" class="form-control" value="{{ $book->book_image ?? old('book_image') }}">
+  <input type="file" class="form-control" name="book_image" value="{{ $book->book_image ?? old('book_image') }}">
 </div>
 <div class="md-form">
   <input type="radio" name="state" class="form-control" value="1">貸出できます

--- a/resources/views/books/index.blade.php
+++ b/resources/views/books/index.blade.php
@@ -5,8 +5,10 @@
 @section('content')
   @include('nav')
   <div class="container">
-    @foreach($books as $book)
-      @include('books.card')
-    @endforeach
+    <div class="row mb-5 mt-3">
+      @foreach($books as $book)
+        @include('books.card')
+      @endforeach
+    </div>
   </div>
 @endsection


### PR DESCRIPTION
目的
・メイン画面スタイル変更
実装
・画像保存方法を変更
・画像ファイル名のみDBに保存
・データそのものはstorage配下に一意の名前で保存
・画像がない場合はダミー画像を表示
課題
・画像表示パスが合わないのか表示できていないので修正必要